### PR TITLE
Fix reading of large messages from the socket

### DIFF
--- a/lib/Tivoka/Client/Connection/Tcp.php
+++ b/lib/Tivoka/Client/Connection/Tcp.php
@@ -102,6 +102,20 @@ class Tcp extends AbstractConnection {
     	return $this;
     }
 
+    private function read_n($length)
+    {
+        $response = '';
+        while ($length > 0) {
+            $chunk = fread($this->socket, $length);
+            if ($chunk === false || strlen($chunk) == 0) {
+                throw new Exception\ConnectionException('Connection to "' . $this->host . ':' . $this->port . '" failed, no mroe bytes');
+            }
+            $response .= $chunk;
+            $length -= strlen($chunk);
+        }
+        return $response;
+    }
+
     /**
      * Sends a JSON-RPC request over plain TCP.
      * @param Request $request,... A Tivoka request.
@@ -139,20 +153,8 @@ class Tcp extends AbstractConnection {
         fflush($this->socket);
 
         // read server response
-        $length = unpack('Nval', fread($this->socket, 4))['val'];
-        $response = '';
-        while ($length > 0) {
-            $chunk = fread($this->socket, $length);
-            if (strlen($chunk) == 0) {
-                throw new Exception\ConnectionException('No more bytes (EOF?)');
-            }
-            $response .= $chunk;
-            $length -= strlen($chunk);
-        }
-
-        if ($response === false) {
-            throw new Exception\ConnectionException('Connection to "' . $this->host . ':' . $this->port . '" failed');
-        }
+        $length = unpack('Nval', $this->read_n(4))['val'];
+        $response = $this->read_n($length);
 
         $request->setResponse($response);
         return $request;

--- a/lib/Tivoka/Client/Connection/Tcp.php
+++ b/lib/Tivoka/Client/Connection/Tcp.php
@@ -39,7 +39,7 @@ use Tivoka\Client\Request;
  * @package Tivoka
  */
 class Tcp extends AbstractConnection {
-    
+
 
     /**
      * Server host.
@@ -84,7 +84,7 @@ class Tcp extends AbstractConnection {
             fclose($this->socket);
         }
     }
-    
+
     /**
      * Changes timeout.
      * @param int $timeout
@@ -93,12 +93,12 @@ class Tcp extends AbstractConnection {
     public function setTimeout($timeout)
     {
     	$this->timeout = $timeout;
-    
+
     	// change timeout for already initialized connection
     	if (isset($this->socket)) {
     		stream_set_timeout($this->socket, $timeout);
     	}
-    
+
     	return $this;
     }
 
@@ -140,7 +140,15 @@ class Tcp extends AbstractConnection {
 
         // read server response
         $length = unpack('Nval', fread($this->socket, 4))['val'];
-        $response = fread($this->socket, $length);
+        $response = '';
+        while ($length > 0) {
+            $chunk = fread($this->socket, $length);
+            if (strlen($chunk) == 0) {
+                throw new Exception\ConnectionException('No more bytes (EOF?)');
+            }
+            $response .= $chunk;
+            $length -= strlen($chunk);
+        }
 
         if ($response === false) {
             throw new Exception\ConnectionException('Connection to "' . $this->host . ':' . $this->port . '" failed');


### PR DESCRIPTION
When reading from a socket the length of the value returned is not guaranteed to be the length asked for, we need to loop until we've read the length we want.
